### PR TITLE
Adding a way to validate if a script is valid or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ dw help
 ```
 
 ```bash
- ____   __  ____  __   _  _  ____   __   _  _  ____
+  ____   __  ____  __   _  _  ____   __   _  _  ____
 (    \ / _\(_  _)/ _\ / )( \(  __) / _\ / )( \(  __)
  ) D (/    \ )( /    \\ /\ / ) _) /    \\ \/ / ) _)
 (____/\_/\_/(__)\_/\_/(_/\_)(____)\_/\_/ \__/ (____)
@@ -94,7 +94,9 @@ Usage: <main class> [-hV] [COMMAND]
   -V, --version   Print version information and exit.
 Commands:
   run            Runs provided DW script.
-  add-wizard     Adds a new Wizard to your network of trusted wizards.
+  wizard         Wizard actions.
+    add            Adds a new Wizard to your network of trusted wizards.
+  validate       Validate if a script is valid or not.
   migrate        Translates a DW1 script into a DW2 script.
   spell          Runs the specified Spell.
     create         Creates a new spell with the given name.

--- a/native-cli/src/main/java/org/mule/weave/cli/DWCLI.java
+++ b/native-cli/src/main/java/org/mule/weave/cli/DWCLI.java
@@ -9,7 +9,9 @@ import org.mule.weave.cli.pico.PicoRunScript;
 import org.mule.weave.cli.pico.PicoRunSpell;
 import org.mule.weave.cli.pico.PicoMigrate;
 import org.mule.weave.cli.pico.PicoUpdateSpells;
+import org.mule.weave.cli.pico.PicoValidateScript;
 import org.mule.weave.cli.pico.PicoVersionProvider;
+import org.mule.weave.cli.pico.PicoWizard;
 import org.mule.weave.dwnative.cli.Console;
 import org.mule.weave.dwnative.cli.DefaultConsole$;
 import picocli.CommandLine;
@@ -44,7 +46,8 @@ public class DWCLI {
             mixinStandardHelpOptions = true,
             subcommands = {
                     PicoRunScript.class,
-                    PicoAddWizard.class,
+                    PicoWizard.class,
+                    PicoValidateScript.class,
                     PicoMigrate.class,
                     PicoRunSpell.class,
                     CommandLine.HelpCommand.class,

--- a/native-cli/src/main/java/org/mule/weave/cli/pico/AbstractPicoExecCommand.java
+++ b/native-cli/src/main/java/org/mule/weave/cli/pico/AbstractPicoExecCommand.java
@@ -51,7 +51,7 @@ public abstract class AbstractPicoExecCommand implements Callable<Integer> {
         );
     }
 
-    public String fileToString(File f) {
+    public static String fileToString(File f) {
         try {
             return Files.readString(f.toPath(), StandardCharsets.UTF_8);
         } catch (IOException e) {
@@ -73,19 +73,19 @@ public abstract class AbstractPicoExecCommand implements Callable<Integer> {
         return doCall();
     }
 
-    protected Option<DataWeaveVersion> calculateRuntimeVersion() {
+    public static Option<DataWeaveVersion> calculateRuntimeVersion(String languageLevel1, CommandLine.Model.CommandSpec spec1) {
         Option<DataWeaveVersion> dataWeaveVersionOption;
         try {
-            dataWeaveVersionOption = Option.apply(languageLevel).map((s) -> DataWeaveVersion.apply(s));
+            dataWeaveVersionOption = Option.apply(languageLevel1).map((s) -> DataWeaveVersion.apply(s));
             if (dataWeaveVersionOption.isDefined()) {
                 DataWeaveVersion dataWeaveVersion = dataWeaveVersionOption.get();
                 DataWeaveVersion currentVersion = DataWeaveVersion.apply();
                 if (dataWeaveVersion.$greater(currentVersion)) {
-                    throw new CommandLine.ParameterException(spec.commandLine(), "Invalid language level, cannot be higher than " + currentVersion.toString());
+                    throw new CommandLine.ParameterException(spec1.commandLine(), "Invalid language level, cannot be higher than " + currentVersion.toString());
                 }
             }
         } catch (NumberFormatException e) {
-            throw new CommandLine.ParameterException(spec.commandLine(), "Invalid language-level option value : `" + languageLevel + "`.");
+            throw new CommandLine.ParameterException(spec1.commandLine(), "Invalid language-level option value : `" + languageLevel1 + "`.");
         }
         return dataWeaveVersionOption;
     }

--- a/native-cli/src/main/java/org/mule/weave/cli/pico/PicoAddWizard.java
+++ b/native-cli/src/main/java/org/mule/weave/cli/pico/PicoAddWizard.java
@@ -8,8 +8,10 @@ import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
 
+
+
 @CommandLine.Command(
-        name = "add-wizard",
+        name = "add",
         description =
                 "Adds a new Wizard to your network of trusted wizards."
 

--- a/native-cli/src/main/java/org/mule/weave/cli/pico/PicoRepl.java
+++ b/native-cli/src/main/java/org/mule/weave/cli/pico/PicoRepl.java
@@ -31,7 +31,7 @@ public class PicoRepl extends AbstractPicoExecCommand {
                 Optional.ofNullable(inputs).map((s) -> toScalaMap(s)).orElse(Map$.MODULE$.<String, File>empty()),
                 Optional.ofNullable(literalInput).map((s) -> toScalaMap(s)).orElse(Map$.MODULE$.<String, String>empty()),
                 Option.apply(privileges).map((s) -> JavaConverters.asScalaBuffer(s).toSeq()),
-                calculateRuntimeVersion()
+                calculateRuntimeVersion(languageLevel, spec)
         );
         ReplCommand replCommand = new ReplCommand(replConfiguration, console);
         return replCommand.exec();

--- a/native-cli/src/main/java/org/mule/weave/cli/pico/PicoRunSpell.java
+++ b/native-cli/src/main/java/org/mule/weave/cli/pico/PicoRunSpell.java
@@ -127,7 +127,7 @@ public class PicoRunSpell extends AbstractPicoRunCommand {
         final SpellDependencyManager manager = new SpellDependencyManager(spellFolder, console);
         final Function1<NativeRuntime, DependencyResolutionResult[]> resolver = (nr) -> manager.resolveDependencies(nr);
 
-        Option<DataWeaveVersion> dataWeaveVersionOption = calculateRuntimeVersion();
+        Option<DataWeaveVersion> dataWeaveVersionOption = calculateRuntimeVersion(languageLevel, spec);
 
         final WeaveRunnerConfig config = WeaveRunnerConfig.apply(
                 new String[]{srcFolder.getAbsolutePath()},

--- a/native-cli/src/main/java/org/mule/weave/cli/pico/PicoWizard.java
+++ b/native-cli/src/main/java/org/mule/weave/cli/pico/PicoWizard.java
@@ -1,0 +1,21 @@
+package org.mule.weave.cli.pico;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "wizard",
+        description = "Wizard actions.",
+        subcommands = {
+                PicoAddWizard.class
+        }
+)
+public class PicoWizard implements Runnable {
+
+    @CommandLine.Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public void run() {
+        spec.commandLine().usage(System.out);
+    }
+}

--- a/native-cli/src/main/scala/org/mule/weave/dwnative/NativeRuntime.scala
+++ b/native-cli/src/main/scala/org/mule/weave/dwnative/NativeRuntime.scala
@@ -101,7 +101,7 @@ class NativeRuntime(libDir: File, path: Array[File], console: Console, maybeLang
     }
   }
 
-  private def compileScript(script: String, inputs: ScriptingBindings, nameIdentifier: NameIdentifier, defaultOutputMimeType: String) = {
+  def compileScript(script: String, inputs: ScriptingBindings, nameIdentifier: NameIdentifier, defaultOutputMimeType: String): DataWeaveScript = {
     var config = weaveScriptingEngine.newConfig()
       .withScript(script)
       .withInputs(inputs.entries().map(wi => new InputType(wi, None)).toArray)

--- a/native-cli/src/main/scala/org/mule/weave/dwnative/cli/commands/VerifyWeaveCommand.scala
+++ b/native-cli/src/main/scala/org/mule/weave/dwnative/cli/commands/VerifyWeaveCommand.scala
@@ -1,0 +1,45 @@
+package org.mule.weave.dwnative.cli.commands
+
+import org.mule.weave.dwnative.NativeRuntime
+import org.mule.weave.dwnative.cli.Console
+import org.mule.weave.dwnative.utils.DataWeaveUtils
+import org.mule.weave.v2.parser.ast.variables.NameIdentifier
+import org.mule.weave.v2.parser.phase.CompilationException
+import org.mule.weave.v2.runtime.ScriptingBindings
+import org.mule.weave.v2.utils.DataWeaveVersion
+
+class VerifyWeaveCommand(val config: WeaveVerifyConfig, console: Console) extends WeaveCommand {
+  val weaveUtils = new DataWeaveUtils(console)
+
+  def exec(): Int = {
+    var exitCode: Int = ExitCodes.SUCCESS
+    val nativeRuntime: NativeRuntime = new NativeRuntime(weaveUtils.getLibPathHome(), Array(), console, config.maybeLanguageLevel)
+    val weaveModule = config.scriptToRun(nativeRuntime)
+    try {
+      console.info(s"Compiling `${weaveModule.nameIdentifier}`...")
+      val bindings = ScriptingBindings()
+      config.inputs.foreach((input) => {
+        bindings.addBinding(input, "")
+      })
+      nativeRuntime.compileScript(weaveModule.content, bindings, NameIdentifier(weaveModule.nameIdentifier), "")
+      console.info(s"No errors found.")
+    } catch {
+      case ce: CompilationException => {
+        val ee = ce.getErrorMessages()
+        ee.foreach((em) => {
+          console.error(em)
+        })
+        console.info(s"${ee.length} errors found")
+        exitCode = ExitCodes.FAILURE
+      }
+    }
+    exitCode
+  }
+}
+
+case class WeaveVerifyConfig(
+                              scriptToRun: NativeRuntime => WeaveModule,
+                              maybeLanguageLevel: Option[DataWeaveVersion],
+                              inputs: Array[String]
+                            )
+


### PR DESCRIPTION
Adding a new command called validate that allows the user to verify if a DW script is a correct script it will verify it parses references and types